### PR TITLE
[PERF] 다중 영상 세션에서 CPU 사용량 및 INP 개선

### DIFF
--- a/src/components/common/MicMoreMenu/DropdownMenu/index.tsx
+++ b/src/components/common/MicMoreMenu/DropdownMenu/index.tsx
@@ -8,8 +8,6 @@ import {
   VolumeLabel,
   VolumeTooltip
 } from "./MicMoreMenu.styles";
-
-// import { OptionsIcon } from "assets/icons/black";
 import { useIconSet } from "lib/hooks/useIconSet";
 
 interface MicMoreMenuProps {
@@ -27,7 +25,6 @@ const MicMoreMenu: React.FC<MicMoreMenuProps> = ({
   volume,
   onVolumeChange,
 }) => {
-  
   const { OptionsIcon } = useIconSet();
   const [menuOpen, setMenuOpen] = useState(false);
   const [showVolumeControl, setShowVolumeControl] = useState(false);
@@ -106,11 +103,11 @@ const MicMoreMenu: React.FC<MicMoreMenuProps> = ({
                     통화방 마이크 끄기
                 </MenuItem>
             )}
-            {isCurrentUserRoomLeader && (
+            {/* {isCurrentUserRoomLeader && (
                 <MenuItem onClick={handleVideoOffClick}>
                     통화방 비디오 끄기
                 </MenuItem>
-            )}
+            )} */}
         </Menu>
         )}
     </div>

--- a/src/components/common/Sidebar/ParticipantsPanel/components/ParticipantItem.tsx
+++ b/src/components/common/Sidebar/ParticipantsPanel/components/ParticipantItem.tsx
@@ -27,7 +27,7 @@ const ParticipantItem: React.FC<Props> = ({ participant, isHandRaised, isCurrent
 
   const handleToggleMute = () => {
     // 음소거 토글 로직
-    alert(`마이크 음소거 토글 - ${participant.username}`);
+    alert(`마이크 음소거 토글 - ${participant.sessionId}`);
   };
 
   const handleToggleVideoOff = () => {

--- a/src/components/common/Video/ParticipantVideo.styles.ts
+++ b/src/components/common/Video/ParticipantVideo.styles.ts
@@ -13,12 +13,17 @@ export const ParticipantContainer = styled.div<{ isPreview?: boolean, isSpeaking
 `;
 
 export const StyledVideo = styled.video`
+  position: absolute;   /* 🔥 추가 */
+  inset: 0;             /* 🔥 추가 */
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;       /* 🔥 안정화 */
 `;
 
 export const Placeholder = styled.div<{ isPreview?: boolean, bgColor?: string }>`
+  position: absolute;     /* 🔥 추가 */
+  inset: 0;               /* 🔥 추가 */
   width: 100%;
   height: 100%;
   background-color: #444;

--- a/src/components/common/Video/ParticipantVideo.tsx
+++ b/src/components/common/Video/ParticipantVideo.tsx
@@ -1,4 +1,11 @@
-import React, { forwardRef, useState, useEffect } from 'react';
+import React, {
+  forwardRef,
+  useState,
+  useEffect,
+  useCallback,
+  memo
+} from "react";
+
 import {
   ParticipantContainer,
   StyledVideo,
@@ -6,15 +13,13 @@ import {
   Placeholder,
   UsernameContent,
   Icon
-} from './ParticipantVideo.styles';
+} from "./ParticipantVideo.styles";
 
-import EmojiEffects from '../EmojiEffects';
-
-import useVoiceActivityDetection from 'lib/hooks/useVoiceActivityDetection';
-import useSpeakingScore from 'lib/hooks/useSpeakingScore';
-
-import { getUserColor } from 'lib/color/colorManager';
-import { useIconSet } from 'lib/hooks/useIconSet';
+import EmojiEffects from "../EmojiEffects";
+import useVoiceActivityDetection from "lib/hooks/useVoiceActivityDetection";
+import useSpeakingScore from "lib/hooks/useSpeakingScore";
+import { getUserColor } from "lib/color/colorManager";
+import { useIconSet } from "lib/hooks/useIconSet";
 
 type Props = {
   sessionId: string;
@@ -26,78 +31,81 @@ type Props = {
   isPreview?: boolean;
   className?: string;
   onSpeakingScoreChange?: (score: number) => void;
-
   volume?: number;
 };
 
 const ParticipantVideo = forwardRef<HTMLVideoElement, Props>(
-  ({ sessionId, username, isVideoOn, isAudioOn, emojiName, mySessionId, isPreview, onSpeakingScoreChange, className, volume }, ref) => {
-
+  (
+    {
+      sessionId,
+      username,
+      isVideoOn,
+      isAudioOn,
+      emojiName,
+      mySessionId,
+      isPreview,
+      onSpeakingScoreChange,
+      className,
+      volume = 50
+    },
+    ref
+  ) => {
     const { RedMicOffIcon } = useIconSet();
     const [mediaStream, setMediaStream] = useState<MediaStream | null>(null);
+
+    const handleLoadedMetadata = useCallback(
+      (e: React.SyntheticEvent<HTMLVideoElement>) => {
+        const video = e.currentTarget;
+        if (video.srcObject instanceof MediaStream) {
+          setMediaStream(video.srcObject);
+        }
+      },
+      []
+    );
 
     useEffect(() => {
       const video = (ref as React.RefObject<HTMLVideoElement>)?.current;
       if (!video) return;
 
-      let mounted = true;
+      const safeVolume =
+        Number.isFinite(volume) && volume >= 0 && volume <= 100
+          ? volume / 100
+          : 0.5;
 
-      const checkStream = () => {
-        if (!mounted) return;
-
-        if (video.srcObject instanceof MediaStream) {
-          setMediaStream(video.srcObject);
-          console.log(`[${sessionId}] MediaStream set.`);
-        } else {
-          setTimeout(checkStream, 100);
-        }
-      };
-
-      checkStream();
-
-      return () => {
-        mounted = false;
-      };
-    }, [ref]);
-
-    useEffect(() => {
-      const video = (ref as React.RefObject<HTMLVideoElement>)?.current;
-      if (video) {
-        const vol = Number(volume);
-        if (!isNaN(vol) && isFinite(vol) && vol >= 0 && vol <= 100) {
-          video.volume = vol / 100;
-        } else {
-          video.volume = 0.5; // 기본값 설정 (예: 50%)
-        }
-      }
+      video.volume = safeVolume;
     }, [volume, ref]);
-
 
     const isSpeaking = useVoiceActivityDetection(mediaStream, isAudioOn);
     const speakingScore = useSpeakingScore(isSpeaking);
 
     useEffect(() => {
-      if (onSpeakingScoreChange) {
-        onSpeakingScoreChange(speakingScore);
-      }
+      onSpeakingScoreChange?.(speakingScore);
     }, [speakingScore, onSpeakingScoreChange]);
 
     return (
-      <ParticipantContainer id={sessionId} isPreview={isPreview} className={className} isSpeaking={isSpeaking}>
-          <StyledVideo
-            id={`video-${sessionId}`}
-            ref={ref}
-            autoPlay
-            muted={isPreview ? false : sessionId === mySessionId || !isAudioOn}
-            playsInline
-            style={{ display: isVideoOn ? 'block' : 'none' }}
-          />
-          
-          {!isVideoOn && (
-            <Placeholder bgColor={getUserColor(sessionId)} isPreview={isPreview}>
-              <span>{username.charAt(0).toUpperCase()}</span>
-            </Placeholder>
-          )}
+      <ParticipantContainer
+        id={sessionId}
+        isPreview={isPreview}
+        className={className}
+        isSpeaking={isSpeaking}
+      >
+        <StyledVideo
+          ref={ref}
+          autoPlay
+          playsInline
+          muted={isPreview ? false : sessionId === mySessionId || !isAudioOn}
+          style={{ display: isVideoOn ? "block" : "none" }}
+          onLoadedMetadata={handleLoadedMetadata}
+        />
+
+        {!isVideoOn && (
+          <Placeholder
+            bgColor={getUserColor(sessionId)}
+            isPreview={isPreview}
+          >
+            <span>{username.charAt(0).toUpperCase()}</span>
+          </Placeholder>
+        )}
 
         <UsernameOverlay>
           <UsernameContent>
@@ -109,10 +117,11 @@ const ParticipantVideo = forwardRef<HTMLVideoElement, Props>(
             {username}
           </UsernameContent>
         </UsernameOverlay>
-        <EmojiEffects emojiName={emojiName}/>
+
+        <EmojiEffects emojiName={emojiName} />
       </ParticipantContainer>
     );
   }
 );
 
-export default ParticipantVideo;
+export default memo(ParticipantVideo);

--- a/src/components/common/Video/ParticipantVideo.tsx
+++ b/src/components/common/Video/ParticipantVideo.tsx
@@ -94,7 +94,9 @@ const ParticipantVideo = forwardRef<HTMLVideoElement, Props>(
           autoPlay
           playsInline
           muted={isPreview ? false : sessionId === mySessionId || !isAudioOn}
-          style={{ display: isVideoOn ? "block" : "none" }}
+          width="16"
+          height="9"
+          style={{opacity: isVideoOn ? 1 : 0}}
           onLoadedMetadata={handleLoadedMetadata}
         />
 

--- a/src/lib/hooks/useSortedSpeakers.ts
+++ b/src/lib/hooks/useSortedSpeakers.ts
@@ -1,5 +1,3 @@
-
-
 import { useState, useEffect } from 'react';
 
 interface SpeakerScores {

--- a/src/lib/hooks/useSpeakingScore.ts
+++ b/src/lib/hooks/useSpeakingScore.ts
@@ -25,7 +25,15 @@ export default function useSpeakingScore(
         ? Math.min(scoreRef.current + increment, maxScore)
         : scoreRef.current * decayRate;
 
-      setScore(Math.round(scoreRef.current));
+        const newScore = Math.round(scoreRef.current);
+
+        setScore(prev => {
+          if (Math.abs(prev - newScore) < 3) {
+            return prev;
+          }
+          return newScore;
+        });
+      // setScore(Math.round(scoreRef.current));
     }, intervalMs);
 
     return () => clearInterval(interval);

--- a/src/lib/hooks/useVoiceActivityDetection.ts
+++ b/src/lib/hooks/useVoiceActivityDetection.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
+let sharedAudioContext: AudioContext | null = null;
+
 interface VADOptions {
   intervalMs?: number;
   threshold?: number;
@@ -10,7 +12,8 @@ export default function useVoiceActivityDetection(
   isAudioOn: boolean,
   options: VADOptions = {}
 ) {
-  const { intervalMs = 200, threshold = 0.05 } = options;
+  // const { intervalMs = 200, threshold = 0.05 } = options;
+  const { intervalMs = 300, threshold = 0.05 } = options;
   const [isSpeaking, setIsSpeaking] = useState(false);
   const audioContextRef = useRef<AudioContext | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
@@ -22,9 +25,16 @@ export default function useVoiceActivityDetection(
       return;
     }
 
-    const audioContext = new AudioContext();
+    // const audioContext = new AudioContext();
+
+    if (!sharedAudioContext) {
+      sharedAudioContext = new AudioContext();
+    }
+    const audioContext = sharedAudioContext;
+
     const analyser = audioContext.createAnalyser();
-    analyser.fftSize = 512;
+    // analyser.fftSize = 512;
+    analyser.fftSize = 256;
 
     const source = audioContext.createMediaStreamSource(stream);
     source.connect(analyser);
@@ -52,7 +62,7 @@ export default function useVoiceActivityDetection(
       clearInterval(interval);
       source.disconnect();
       analyser.disconnect();
-      audioContext.close();
+      // audioContext.close();
     };
   }, [stream, isAudioOn]);
 

--- a/src/pages/room/conference/Conference.styles.ts
+++ b/src/pages/room/conference/Conference.styles.ts
@@ -42,18 +42,33 @@ export const GalleryWrapper = styled.div`
     height:100%;
 `;
 
-export const ParticipantVideoGroup = styled.div<{ $cols: number }>`
+// export const ParticipantVideoGroup = styled.div<{ $cols: number }>`
+//     display: grid;
+//     grid-template-columns: ${({ $cols }) => `repeat(${Math.max($cols, 1)}, 1fr)`};
+//     // grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+//     // grid-auto-rows: auto;
+//     gap: ${({theme})=>theme.spacings.xs};
+//     width: 100%;
+//     max-width: ${({ $cols }) => {
+//         if ($cols === 2 || $cols === 3) return '60%';
+//         if ($cols === 4) return '80%';
+//         return '95%';
+//     }};
+//     justify-items: center;
+//     align-items: start;
+// `;
+
+export const ParticipantVideoGroup = styled.div`
   display: grid;
-  grid-template-columns: ${({ $cols }) => `repeat(${Math.max($cols, 1)}, 1fr)`};
-  grid-auto-rows: auto;
-  gap: ${({theme})=>theme.spacings.xs};
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: ${({ theme }) => theme.spacings.xs};
+
   width: 100%;
-  max-width: ${({ $cols }) => {
-    if ($cols === 2 || $cols === 3) return '60%';
-    if ($cols === 4) return '80%';
-    return '95%';
-  }};
+  min-height: 60vh;
+
+  justify-content: center;
+  align-content: start;
+
   justify-items: center;
   align-items: start;
 `;
-

--- a/src/pages/room/conference/index.tsx
+++ b/src/pages/room/conference/index.tsx
@@ -165,7 +165,8 @@ const Conference: React.FC<ConferenceProps> = ({
     const [selectedMicId, setSelectedMicId] = useState<string | undefined>(audioDeviceId);
     const [selectedVideoId, setSelectedVideoId] = useState<string | undefined>(videoDeviceId);
 
-    const displayStreamRef = useRef<MediaStream | null>(null); // 꼭 선언해 주세요
+    const displayStreamRef = useRef<MediaStream | null>(null); 
+    const originalTracksRef = useRef<{ video?: MediaStreamTrack; audio?: MediaStreamTrack }>({});
 
     const handleScreenSharingToggle = async () => {
         const participant = participantsRef.current[userData.sessionId];
@@ -195,16 +196,10 @@ const Conference: React.FC<ConferenceProps> = ({
                 const screenTrack = displayStream.getVideoTracks()[0];
                 const micTrack = micStream.getAudioTracks()[0];
 
-                const prevVideoTrack = videoSender.track;
-                const prevAudioTrack = audioSender.track;
-
-                setVideoTracks(prev => ({
-                    ...prev,
-                    [userData.sessionId]: {
-                        video: prevVideoTrack,
-                        audio: prevAudioTrack,
-                    }
-                }));
+                originalTracksRef.current = {
+                    video: videoSender.track ?? undefined,
+                    audio: audioSender.track ?? undefined
+                };
 
                 await videoSender.replaceTrack(screenTrack);
                 await audioSender.replaceTrack(micTrack);
@@ -214,9 +209,11 @@ const Conference: React.FC<ConferenceProps> = ({
 
                 setScreenSharing(true);
 
-                screenTrack.onended = () => {
-                    stopScreenSharing();
-                };
+                screenTrack.addEventListener("ended", () => {
+                    if (screenSharing) {
+                        handleScreenSharingToggle();
+                    }
+                });
             } catch (err) {
                 console.error("화면 공유 시작 오류:", err);
             }
@@ -225,23 +222,29 @@ const Conference: React.FC<ConferenceProps> = ({
         }
 
         async function stopScreenSharing() {
-            const prevTracks = videoTracks[userData.sessionId];
-            if (prevTracks?.video) await videoSender.replaceTrack(prevTracks.video);
-            if (prevTracks?.audio) await audioSender.replaceTrack(prevTracks.audio);
+            const original = originalTracksRef.current;
+
+            if (original.video) {
+                await videoSender.replaceTrack(original.video);
+            }
+            if (original.audio) {
+                await audioSender.replaceTrack(original.audio);
+            }
+
+            if (displayStreamRef.current) {
+                displayStreamRef.current.getTracks().forEach(track => track.stop());
+                displayStreamRef.current = null;
+            }
 
             const localVideoEl = videoRefs.current[userData.sessionId]?.current;
             if (localVideoEl && localStreamRef.current) {
                 localVideoEl.srcObject = localStreamRef.current;
             }
 
-            // ✅ displayStream이 살아 있으면 stop
-            if (displayStreamRef.current) {
-                displayStreamRef.current.getTracks().forEach(track => track.stop());
-                displayStreamRef.current = null;
-            }
+            originalTracksRef.current = {};
 
             setScreenSharing(false);
-        }
+            }
     };
 
     const replaceAudioTrack = async (newDeviceId: string) => {
@@ -276,9 +279,9 @@ const Conference: React.FC<ConferenceProps> = ({
     };
 
     const handleMicDeviceChange = (deviceId: string) => {
-        if (deviceId === selectedMicId) return; // 이미 선택된 장치면 무시
+        if (deviceId === selectedMicId) return;
         setSelectedMicId(deviceId);
-        replaceAudioTrack(deviceId); // 실제 트랙 교체 함수
+        replaceAudioTrack(deviceId);
     };
     const replaceVideoTrack = async (newDeviceId: string) => {
         const participant = participantsRef.current[userData.sessionId];
@@ -310,9 +313,9 @@ const Conference: React.FC<ConferenceProps> = ({
     };
 
     const handleVideoDeviceChange = (deviceId: string) => {
-        if (deviceId === selectedVideoId) return; // 중복 방지
+        if (deviceId === selectedVideoId) return;
         setSelectedVideoId(deviceId);
-        replaceVideoTrack(deviceId); // 트랙 교체 로직 호출
+        replaceVideoTrack(deviceId);
     };
 
 
@@ -440,7 +443,7 @@ const Conference: React.FC<ConferenceProps> = ({
             ws.current.send(JSON.stringify(message));
         };
 
-        // ✅ 브라우저 닫기/새로고침 시 exitRoom 전송
+        // 브라우저 닫기/새로고침 시 exitRoom 전송
         const handleBeforeUnload = () => {
             if (ws.current && ws.current.readyState === WebSocket.OPEN) {
                 const exitMessage = {
@@ -483,6 +486,7 @@ const Conference: React.FC<ConferenceProps> = ({
                     break;
                 case 'exitRoom':
                     userLeft(parsedMessage);
+                    
                     break;
                 case 'leaderChanged':
                     handleLeaderChanged(parsedMessage);
@@ -499,9 +503,6 @@ const Conference: React.FC<ConferenceProps> = ({
                 case 'videoStateChange':
                     handleVideoStateChange(parsedMessage);
                     break;
-                // case 'sendPrivateEmoji': //비공개 이모지
-                //     handleEmojiMessage(parsedMessage, true);
-                //     break;
                 case 'sendPublicEmoji': //공개 이모지
                     handleEmojiMessage(parsedMessage);
                     break;
@@ -528,8 +529,6 @@ const Conference: React.FC<ConferenceProps> = ({
                     stop();
                     finalizeRecordingSession();
                     break;
-                // case 'saveRecording': // 녹화본 다운로드
-                //     break;
                 case 'pauseRecording': // 녹화 일시정지
                     pause();
                     setRecordingPaused(true);
@@ -632,7 +631,7 @@ const Conference: React.FC<ConferenceProps> = ({
             }));
         }
 
-        // 💡 렌더링 이후까지 기다렸다가 비디오 연결 시도
+        // 렌더링 이후까지 기다렸다가 비디오 연결 시도
         setTimeout(() => {
             const videoElement = videoRefs.current[sender.sessionId]?.current;
 
@@ -666,7 +665,7 @@ const Conference: React.FC<ConferenceProps> = ({
                 }
                 });
             });
-        }, 1000); // 💡 100ms 정도의 짧은 지연
+        }, 1000); // 100ms 정도의 짧은 지연
     };
 
 
@@ -718,8 +717,17 @@ const Conference: React.FC<ConferenceProps> = ({
         console.log("videoRefs.current[msg.sessionId]",videoRefs.current[msg.sessionId]);
         const localVideoRef = videoRefs.current[msg.sessionId];
 
+        const VIDEO_CONSTRAINTS = {
+            width: { ideal: 320, max: 320 },
+            height: { ideal: 240, max: 240 },
+            frameRate: { ideal: 10, max: 10 }
+        };
+
         // getUserMedia → WebRTC 연결
-        navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+        navigator.mediaDevices.getUserMedia({ 
+            audio: true, 
+            video: VIDEO_CONSTRAINTS 
+        })
             .then((stream) => {
                  // 스트림 전역에 저장
                 localStreamRef.current = stream;
@@ -738,10 +746,6 @@ const Conference: React.FC<ConferenceProps> = ({
                         console.warn(`[Participant ${msg.sessionId}] video element not ready yet.`);
                     }
                 }, 100); // 100ms 딜레이 (필요에 따라 조절)
-
-                // if (localVideoRef.current) {
-                //     localVideoRef.current.srcObject = stream;
-                // }
 
                 const options = {
                     configuration: {iceServers: iceServers},
@@ -878,6 +882,7 @@ const Conference: React.FC<ConferenceProps> = ({
         }
 
         console.log("👋 사용자 퇴장 처리 시작:", participant.username);
+        addSystemMessage(`${participant.username}님이 퇴장했습니다.`);
 
         // 1. WebRTC 연결 정리
         participant.dispose();
@@ -1164,7 +1169,7 @@ const Conference: React.FC<ConferenceProps> = ({
                         mySessionId={userData.sessionId}
                         emojiName={emojiMessages.find(msg => msg.sessionId === sessionId)?.emoji}
                         onSpeakingScoreChange={(score) => handleSpeakingScoreChange(sessionId, score)}
-                        className={isMain ? 'main-video' : 'sub-video'} // ⬅️ 스타일 구분
+                        className={isMain ? 'main-video' : 'sub-video'}
                         volume={volume}
                     />
                     );

--- a/src/pages/room/conference/index.tsx
+++ b/src/pages/room/conference/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as kurentoUtils from 'kurento-utils';
 import fixWebmDuration from 'webm-duration-fix';
@@ -101,6 +101,7 @@ const Conference: React.FC<ConferenceProps> = ({
     //참가자 점수 저장
     const [speakingScores, setSpeakingScores] = useState<{ [id: string]: number }>({});
     const [firstSpokenTimestamps, setFirstSpokenTimestamps] = useState<{ [id: string]: number }>({});
+    
 
     const handleMicListToggle = () => {
         setMicListVisible(prev => {
@@ -131,10 +132,6 @@ const Conference: React.FC<ConferenceProps> = ({
     };
     const topSpeaker = useTopSpeaker(speakingScores);
     const topSpeakerRef = useRef(topSpeaker);
-    const sortedSpeakerIds = useSortedSpeakers(speakingScores, firstSpokenTimestamps);
-
-
-    
 
     const handleMicToggle = () => {
         const newMicState = !micOn;
@@ -372,14 +369,20 @@ const Conference: React.FC<ConferenceProps> = ({
 
     const [participants, setParticipants] = useState<{ [sessionId: string]: Participant }>({});
     const participantsRef = useRef<{ [sessionId: string]: Participant }>({});
+    const sortedSpeakerIds = useMemo(() => {
+    const ids = Object.keys(participants);
+        if (!topSpeaker?.id) return ids;
+        return [
+            topSpeaker.id,
+            ...ids.filter(id => id !== topSpeaker.id)
+        ];
+    }, [participants, topSpeaker]);
     const [roomLeader, setRoomLeader] = useState<{ sessionId: string; username: string }>({ sessionId: '', username: ''});
     const [recordedFiles, setRecordedFiles] = useState<RecordedFile[]>([]);
     const [elapsed, setElapsed] = useState(0); //녹화 시간 저장
     const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
     const [granted, setGranted] = useState<boolean | null>(null);
 
-
-    
     const [participantVolumes, setParticipantVolumes] = useState<Record<string, number>>({});
     const handleVolumeChange = (sessionId: string, newVolume: number) => {
         setParticipantVolumes(prev => ({ ...prev, [sessionId]: newVolume }));
@@ -1148,7 +1151,7 @@ const Conference: React.FC<ConferenceProps> = ({
                     />
                     );
                 })} */}
-                <ParticipantVideoGroup $cols={sortedSpeakerIds.length-1}>
+                <ParticipantVideoGroup>
                 {sortedSpeakerIds.map((sessionId, index) => {
                     
                     const participant = participants[sessionId];


### PR DESCRIPTION
## 🔥 *Pull requests*

🚩**작업 브랜치**
- perf/#32-webrtc-cpu-optimization

📜**작업 내용**
- 5명 이상 WebRTC 영상 세션 연길 시 발생하던 CPU 사용량 급증 문제 개선
- 메인 스레드 점유로 인해 증가하던 INP 최적화
- 참가자 수 증가 시 발생하던 레이아웃 재계산을 완화 -> CLS 안정화
- 영상 그리드 구조를 단순화 및 불필요한 레이아웃 변동 최소화

## ⚠️ 참고 사항
- 다중 영상 세션(5명 이상) 환경에서 CPU 점유율과 메인 스레드 사용량을 중점적으로 테스트
- WebRTC 특성상 참가자 수 증가 및 트랙 attach 시점에 일시적인 레이아웃 변동이 발생 가능
- 레이아웃 구조 변경은 최소화하여 기존 로직(이모지, speaking 정렬, 세션 관리)에 영향을 주지 않도록 유지
- 해상도 및 프레임 전략은 향후 네트워크/환경에 따라 추가 최적화 가능성 있

## 📊 성능 측정 결과 (로컬 기준)

| 항목 | 개선 전 | 개선 후 |
|------|---------|---------|
| CLS | ~0.30 | ~0.09 |
| INP | ~240ms | ~64ms |
| LCP | ~0.51s | ~0.11s |

## 🔎 관련 이슈
- 예: Closes: #32 

## 📋 PR 유형
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 코드 변환 (JavaScript -> TypeScript 변환)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

## ✅ **확인 사항**
- [x] 변경 사항 로컬에서 확인
- [x] 테스트 완료
- [ ] 문서 수정 완료
- [ ] UI/UX 리뷰 완료
