### PR TITLE
[FIX]장치 변경 시 트랙 누수 방지

### DIFF
--- a/src/pages/room/conference/index.tsx
+++ b/src/pages/room/conference/index.tsx
@@ -247,6 +247,37 @@ const Conference: React.FC<ConferenceProps> = ({
             }
     };
 
+    // const replaceAudioTrack = async (newDeviceId: string) => {
+    //     const participant = participantsRef.current[userData.sessionId];
+    //     if (!participant?.rtcPeer) return;
+
+    //     const audioSender = participant.rtcPeer.peerConnection
+    //         .getSenders()
+    //         .find((s) => s.track?.kind === "audio");
+
+    //     if (!audioSender) return;
+
+    //     const newStream = await navigator.mediaDevices.getUserMedia({
+    //         audio: { deviceId: { exact: newDeviceId } }
+    //     });
+
+    //     const newAudioTrack = newStream.getAudioTracks()[0];
+    //     await audioSender.replaceTrack(newAudioTrack);
+
+    //     // 로컬 비디오 스트림에도 반영
+    //     const localStream = localStreamRef.current;
+    //     if (localStream) {
+    //         localStream.removeTrack(localStream.getAudioTracks()[0]);
+    //         localStream.addTrack(newAudioTrack);
+    //     }
+
+    //     // UI에서도 듣기 반영
+    //     const localVideoEl = videoRefs.current[userData.sessionId]?.current;
+    //     if (localVideoEl) {
+    //         localVideoEl.srcObject = localStream;
+    //     }
+    // };
+
     const replaceAudioTrack = async (newDeviceId: string) => {
         const participant = participantsRef.current[userData.sessionId];
         if (!participant?.rtcPeer) return;
@@ -254,27 +285,59 @@ const Conference: React.FC<ConferenceProps> = ({
         const audioSender = participant.rtcPeer.peerConnection
             .getSenders()
             .find((s) => s.track?.kind === "audio");
-
         if (!audioSender) return;
 
-        const newStream = await navigator.mediaDevices.getUserMedia({
-            audio: { deviceId: { exact: newDeviceId } }
-        });
+        // ✅ 1) 교체 전 기존 트랙 백업
+        const oldSenderTrack = audioSender.track ?? null;
 
-        const newAudioTrack = newStream.getAudioTracks()[0];
-        await audioSender.replaceTrack(newAudioTrack);
+        let newStream: MediaStream | null = null;
+        let replaced = false;
 
-        // 로컬 비디오 스트림에도 반영
-        const localStream = localStreamRef.current;
-        if (localStream) {
-            localStream.removeTrack(localStream.getAudioTracks()[0]);
-            localStream.addTrack(newAudioTrack);
-        }
+        try {
+            newStream = await navigator.mediaDevices.getUserMedia({
+            audio: { deviceId: { exact: newDeviceId } },
+            });
 
-        // UI에서도 듣기 반영
-        const localVideoEl = videoRefs.current[userData.sessionId]?.current;
-        if (localVideoEl) {
-            localVideoEl.srcObject = localStream;
+            const newAudioTrack = newStream.getAudioTracks()[0] ?? null;
+            if (!newAudioTrack) {
+            console.warn("[replaceAudioTrack] No audio track from getUserMedia");
+            return;
+            }
+
+            // ✅ 2) sender 트랙 교체
+            await audioSender.replaceTrack(newAudioTrack);
+            replaced = true;
+
+            // ✅ 3) 교체가 성공한 뒤에만 기존 트랙 stop (핵심)
+            oldSenderTrack?.stop();
+
+            // ✅ 4) localStreamRef에도 반영 + 기존 트랙 제거/stop
+            const localStream = localStreamRef.current;
+            if (localStream) {
+            localStream.getAudioTracks().forEach((t) => {
+                if (t !== newAudioTrack) {
+                localStream.removeTrack(t);
+                t.stop();
+                }
+            });
+
+            if (!localStream.getAudioTracks().includes(newAudioTrack)) {
+                localStream.addTrack(newAudioTrack);
+            }
+            }
+
+            // UI 반영
+            const localVideoEl = videoRefs.current[userData.sessionId]?.current;
+            if (localVideoEl) {
+            localVideoEl.srcObject = localStreamRef.current;
+            }
+        } catch (err) {
+            console.error("[replaceAudioTrack] failed:", err);
+        } finally {
+            // ✅ 교체 실패/중단이면 새로 연 stream은 닫아야 “새 장치 점유”가 남지 않음
+            if (!replaced) {
+            newStream?.getTracks().forEach((t) => t.stop());
+            }
         }
     };
 
@@ -283,6 +346,36 @@ const Conference: React.FC<ConferenceProps> = ({
         setSelectedMicId(deviceId);
         replaceAudioTrack(deviceId);
     };
+    // const replaceVideoTrack = async (newDeviceId: string) => {
+    //     const participant = participantsRef.current[userData.sessionId];
+    //     if (!participant?.rtcPeer) return;
+
+    //     const videoSender = participant.rtcPeer.peerConnection
+    //         .getSenders()
+    //         .find((s) => s.track?.kind === "video");
+
+    //     if (!videoSender) return;
+
+    //     const newStream = await navigator.mediaDevices.getUserMedia({
+    //         video: { deviceId: { exact: newDeviceId } }
+    //     });
+
+    //     const newVideoTrack = newStream.getVideoTracks()[0];
+    //     await videoSender.replaceTrack(newVideoTrack);
+
+    //     const localStream = localStreamRef.current;
+    //     if (localStream) {
+    //         localStream.removeTrack(localStream.getVideoTracks()[0]);
+    //         localStream.addTrack(newVideoTrack);
+    //     }
+
+    //     const localVideoEl = videoRefs.current[userData.sessionId]?.current;
+    //     if (localVideoEl) {
+    //         localVideoEl.srcObject = localStream;
+    //     }
+    // };
+
+
     const replaceVideoTrack = async (newDeviceId: string) => {
         const participant = participantsRef.current[userData.sessionId];
         if (!participant?.rtcPeer) return;
@@ -290,25 +383,58 @@ const Conference: React.FC<ConferenceProps> = ({
         const videoSender = participant.rtcPeer.peerConnection
             .getSenders()
             .find((s) => s.track?.kind === "video");
-
         if (!videoSender) return;
 
-        const newStream = await navigator.mediaDevices.getUserMedia({
-            video: { deviceId: { exact: newDeviceId } }
-        });
+        // ✅ 1) 교체 전 기존 트랙 백업
+        const oldSenderTrack = videoSender.track ?? null;
 
-        const newVideoTrack = newStream.getVideoTracks()[0];
-        await videoSender.replaceTrack(newVideoTrack);
+        let newStream: MediaStream | null = null;
+        let replaced = false;
 
-        const localStream = localStreamRef.current;
-        if (localStream) {
-            localStream.removeTrack(localStream.getVideoTracks()[0]);
-            localStream.addTrack(newVideoTrack);
-        }
+        try {
+            newStream = await navigator.mediaDevices.getUserMedia({
+            video: { deviceId: { exact: newDeviceId } },
+            });
 
-        const localVideoEl = videoRefs.current[userData.sessionId]?.current;
-        if (localVideoEl) {
-            localVideoEl.srcObject = localStream;
+            const newVideoTrack = newStream.getVideoTracks()[0] ?? null;
+            if (!newVideoTrack) {
+            console.warn("[replaceVideoTrack] No video track from getUserMedia");
+            return;
+            }
+
+            // ✅ 2) sender 트랙 교체
+            await videoSender.replaceTrack(newVideoTrack);
+            replaced = true;
+
+            // ✅ 3) 교체 성공 후 기존 트랙 stop (핵심)
+            oldSenderTrack?.stop();
+
+            // ✅ 4) localStreamRef에도 반영 + 기존 트랙 제거/stop
+            const localStream = localStreamRef.current;
+            if (localStream) {
+            localStream.getVideoTracks().forEach((t) => {
+                if (t !== newVideoTrack) {
+                localStream.removeTrack(t);
+                t.stop();
+                }
+            });
+
+            if (!localStream.getVideoTracks().includes(newVideoTrack)) {
+                localStream.addTrack(newVideoTrack);
+            }
+            }
+
+            const localVideoEl = videoRefs.current[userData.sessionId]?.current;
+            if (localVideoEl) {
+            localVideoEl.srcObject = localStreamRef.current;
+            }
+        } catch (err) {
+            console.error("[replaceVideoTrack] failed:", err);
+        } finally {
+            // ✅ 교체 실패/중단이면 새로 연 stream 정리
+            if (!replaced) {
+            newStream?.getTracks().forEach((t) => t.stop());
+            }
         }
     };
 


### PR DESCRIPTION
## 🔥 *Pull requests*

🚩**작업 브랜치**
- fix/#36-webrtc-track-leak

📜**작업 내용**

WebRTC 통화 중 마이크/카메라 장치 변경 시 기존 MediaStreamTrack이 종료되지 않아 장치 점유가 누적될 수 있는 문제를 수정

1. replaceAudioTrack
- replaceTrack 성공 이후 기존 audio track에 대해 stop() 처리
- localStreamRef에서 제거된 이전 audio track도 명시적으로 stop()

2.replaceVideoTrack
- replaceTrack 성공 이후 기존 video track에 대해 stop() 처리
- localStreamRef에서 제거된 이전 video track도 명시적으로 stop()

3.장치 변경 실패 시 생성된 임시 MediaStream 정리


## ⚠️ 참고 사항
- 현재 구조상 기본 장치 1개는 유지될 수 있으나, 장치 변경 시 트랙이 누적되지 않는 것을 확인


## 📊 테스트 결과 비교

### 1️⃣ 장치 변경 반복 테스트 (마이크)

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| 마이크 10회 변경 | Audio track 누적 증가 가능 | Audio sender 1개 유지 |
| old audio track 상태 | live 상태 유지 | ended 처리 |
| 장치 점유 | 변경할수록 증가 가능 | 기본 1 + 선택 1 유지 (누적 없음) |

---

### 2️⃣ 장치 변경 반복 테스트 (카메라)

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| 카메라 10회 변경 | Video track 누적 가능 | Video sender 1개 유지 |
| old video track 상태 | live 상태 유지 | ended 처리 |

---

### 3️⃣ WebRTC 내부 상태 확인

| 항목 | 결과 |
|------|------|
| getUserMedia 호출 | 장치 변경 횟수만큼만 발생 |
| Audio sender 개수 | 1개 유지 |
| Video sender 개수 | 1개 유지 |
| Console 에러 | 없음 |

---

### 4️⃣ 성능 테스트

| 상황 | CPU 사용량 |
|------|------------|
| Idle 상태 | ~9% |
| 1~2명 발화 | 15~20% |
| 장치 변경 반복 | 누적 증가 없음 |

## 🔎 관련 이슈
- Fixes: #36 

## 📋 PR 유형
- [ ] 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 코드 변환 (JavaScript -> TypeScript 변환)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

## ✅ **확인 사항**
- [x] 변경 사항 로컬에서 확인
- [x] 테스트 완료
- [ ] 문서 수정 완료
- [ ] UI/UX 리뷰 완료
